### PR TITLE
[hotfix/meeting > develop] 모임 & 가입 신청서 오류 수정, 자잘한 기능 추가  

### DIFF
--- a/src/main/kotlin/com/mohaeng/meeting/presentation/InquireParticipationFormRestController.kt
+++ b/src/main/kotlin/com/mohaeng/meeting/presentation/InquireParticipationFormRestController.kt
@@ -3,6 +3,7 @@ package com.mohaeng.meeting.presentation
 import com.mohaeng.meeting.infrastructure.log.Log
 import com.mohaeng.meeting.query.dao.participationform.ParticipationFormDataDao
 import com.mohaeng.meeting.query.data.participationform.ParticipationFormData
+import com.mohaeng.meeting.query.exception.NotFoundParticipationFormException
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -26,6 +27,11 @@ class InquireParticipationFormRestController(
     @GetMapping("/api/meeting/{meetingId}/participation-form")
     fun inquireUsedApplyFormByMeetingId(
         @PathVariable(name = "meetingId") meetingId: Long,
-    ): ResponseEntity<ParticipationFormData> =
-        ResponseEntity.ok(participationFormDataDao.findUsedParticipationFormByMeetingId(meetingId))
+    ): ResponseEntity<ParticipationFormData> {
+
+        return ResponseEntity.ok(
+            participationFormDataDao.findUsedParticipationFormByMeetingId(meetingId)
+                ?: throw NotFoundParticipationFormException()
+        )
+    }
 }

--- a/src/main/kotlin/com/mohaeng/meeting/query/dao/meeting/MeetingDataDao.kt
+++ b/src/main/kotlin/com/mohaeng/meeting/query/dao/meeting/MeetingDataDao.kt
@@ -7,5 +7,5 @@ import com.mohaeng.meeting.query.data.meeting.MeetingData
  */
 interface MeetingDataDao {
 
-    fun findById(id: Long): MeetingData
+    fun findById(meetingId: Long): MeetingData
 }

--- a/src/main/kotlin/com/mohaeng/meeting/query/data/meeting/MeetingData.kt
+++ b/src/main/kotlin/com/mohaeng/meeting/query/data/meeting/MeetingData.kt
@@ -15,8 +15,6 @@ data class MeetingData @QueryProjection constructor(
 
     val capacity: Int, // 모임 최대 인원
 
-    // 현재 가입한 회원 수는 모임 노출 서비스에서 구현
-
     val createdAt: String, // 생성 시간
 
     val modifiedAt: String, // 최종 수정 시간
@@ -28,4 +26,6 @@ data class MeetingData @QueryProjection constructor(
     val representativeNickname: String, // 모임에서 사용할 별명
 
 ) {
+
+    var numberOfParticipants: Int = 0 // 현재 가입한 회원 수
 }


### PR DESCRIPTION
모임 조회 시 참여한 회원 수 반환하도록 설정

서브쿼리로 구현하려 했다가 성능상 차이도 없을 것 같고, 쿼리를 분리하는 것이 더 관리가 쉬울 것 같아 쿼리 분리하여 구현

모임 조회 시 대표 정보가 제대로 반환되지 않았던 오류 수정